### PR TITLE
SWR - Pälzisch im Abgang

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ttaf2srt
 ========
 
-Simple python script to convert ttaf subtitles to srt subtitles. Note - only tested on
-German 'Tatort' subtitles. Note2 - if using vlc or mplayer, make sure to specify 'utf8'
-as encoding, otherwise, special characters will not render correctly.
+Simple python script to convert ttaf subtitles to srt subtitles. 
+Note - only tested on German 'Pälzisch im Abgang' (SWR) subtitles (www.swr.de/paelzisch-im-abgang/).
+Note2 - if using vlc or mplayer, make sure to specify 'utf8' as encoding, otherwise, special characters will not render correctly.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@ ttaf2srt
 ========
 
 Simple python script to convert ttaf subtitles to srt subtitles. 
-Note - only tested on German 'Pälzisch im Abgang' (SWR) subtitles (www.swr.de/paelzisch-im-abgang/).
+Note - only tested on German 'Pälzisch im Abgang' (SWR) subtitles (www.swr.de/paelzisch-im-abgang/) and 'Tatort' subtitles of November 2015.
 Note2 - if using vlc or mplayer, make sure to specify 'utf8' as encoding, otherwise, special characters will not render correctly.

--- a/ttaf2srt.py
+++ b/ttaf2srt.py
@@ -1,5 +1,22 @@
 #!/usr/bin/env python3
 
+"""
+Usage:
+ttaf2srt subtitlefilettafinput.xml > output.srt
+
+From https://github.com/haraldF/ttaf2srt
+edited for 'SWR - Pälzisch im Abgang' subtitles
+www.swr.de/paelzisch-im-abgang/
+"""
+"""
+From https://github.com/haraldF/ttaf2srt
+
+ttaf2srt
+
+Simple python script to convert ttaf subtitles to srt subtitles.
+Note - only tested on German 'Tatort' subtitles.
+Note2 - if using vlc or mplayer, make sure to specify 'utf8' as encoding, otherwise, special characters will not render correctly.
+"""
 import sys
 from xml.dom import minidom
 
@@ -8,10 +25,10 @@ def dumpText(item):
         if child.nodeType == child.TEXT_NODE:
             print(child.nodeValue, end="")
         elif child.nodeType == child.ELEMENT_NODE:
-            if child.nodeName == "br":
+            if child.nodeName == "tt:br":
                 print()
-            elif child.nodeName == "span":
-                print("<font color=\"" + child.getAttribute("tts:color") + "\">", end="")
+            elif child.nodeName == "tt:span":
+                print("<font color=\"" + styles[child.getAttribute("style")] + "\">", end="")
                 dumpText(child)
                 print("</font>", end="")
             else:
@@ -30,25 +47,25 @@ def dumpHeader(item, subCount):
 def parseStyles(styles):
     result = {}
     for style in styles:
-        result[style.getAttribute('id')] = style.getAttribute('tts:color')
+        result[style.getAttribute('xml:id')] = style.getAttribute('tts:color')
     return result
 
 xmldoc = minidom.parse(sys.argv[1])
 
-header = xmldoc.getElementsByTagName('head')
+header = xmldoc.getElementsByTagName('tt:head')
 if len(header):
-    styling = header[0].getElementsByTagName('styling')
+    styling = header[0].getElementsByTagName('tt:styling')
     if len(styling):
-        styles = parseStyles(styling[0].getElementsByTagName('style'))
+        styles = parseStyles(styling[0].getElementsByTagName('tt:style'))
 
-body = xmldoc.getElementsByTagName('body')
+body = xmldoc.getElementsByTagName('tt:body')
 
-itemlist = body[0].getElementsByTagName('p') 
+itemlist = body[0].getElementsByTagName('tt:p') 
 
 subCount = 0
 
 for item in itemlist:
-    if item.hasAttribute('id'):
+    if item.hasAttribute('xml:id'):
         dumpHeader(item, subCount)
         subCount += 1
         color = styles[item.getAttribute("style")]

--- a/ttaf2srt.py
+++ b/ttaf2srt.py
@@ -7,6 +7,7 @@ ttaf2srt subtitlefilettafinput.xml > output.srt
 From https://github.com/haraldF/ttaf2srt
 edited for 'SWR - Pälzisch im Abgang' subtitles
 www.swr.de/paelzisch-im-abgang/
+and 'Tatort' subtitles.
 """
 """
 From https://github.com/haraldF/ttaf2srt
@@ -50,7 +51,9 @@ def parseStyles(styles):
         result[style.getAttribute('xml:id')] = style.getAttribute('tts:color')
     return result
 
-xmldoc = minidom.parse(sys.argv[1])
+with open(sys.argv[1]) as f:
+    xmldoc = f.read().replace('\n', ' ').replace('\r', '')
+xmldoc = minidom.parseString(xmldoc)
 
 header = xmldoc.getElementsByTagName('tt:head')
 if len(header):


### PR DESCRIPTION
I have changed the script to work for 'Pälzisch im Abgang' (SWR) subtitles ( www.swr.de/paelzisch-im-abgang/ ) downloaded with MediathekView 10.

It should not work any more for old Tatort subtitle as the nodeName and Attribute differ from the original. Interestingly the xml file that I got for "Tatort - Spielverderber" from MediathekView 10 today has same Attributenames and nodeNames as "Pälzisch im Abgang" but VLC does not recognize the generated .srt properly because there are way to many empty lines in it.
